### PR TITLE
Restructure the goat package to be more go idiomatic / friendly to consumers

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,7 +49,7 @@ tasks:
   gen-mocks:
     deps: [gen-proto]
     cmds:
-      - mockery --with-expecter --name "RpcReadWriter" --dir . --output ./gen/mocks --case snake
+      - mockery --with-expecter --name "RpcReadWriter" --dir types --output ./gen/mocks --case snake
       - mockery --with-expecter --dir ./gen/testproto --output ./gen/testproto/mocks --all --keeptree --case snake
     sources:
       - "pkg/**/*.go"

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-package client
+package goat
 
 import (
 	"context"
@@ -7,9 +7,9 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/avos-io/goat"
 	wrapped "github.com/avos-io/goat/gen"
 	"github.com/avos-io/goat/internal"
+	"github.com/avos-io/goat/internal/client"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/encoding/proto"
@@ -17,7 +17,7 @@ import (
 )
 
 type ClientConn struct {
-	mp *RpcMultiplexer
+	mp *client.RpcMultiplexer
 
 	codec encoding.Codec
 
@@ -29,9 +29,9 @@ type ClientConn struct {
 
 var _ grpc.ClientConnInterface = (*ClientConn)(nil)
 
-func NewClientConn(conn goat.RpcReadWriter, source, dest string, opts ...DialOption) *ClientConn {
+func NewClientConn(conn RpcReadWriter, source, dest string, opts ...DialOption) *ClientConn {
 	cc := ClientConn{
-		mp:            NewRpcMultiplexer(conn),
+		mp:            client.NewRpcMultiplexer(conn),
 		codec:         encoding.GetCodec(proto.Name),
 		sourceAddress: source,
 		destAddress:   dest,
@@ -157,7 +157,15 @@ func (cc *ClientConn) newStream(
 		return nil, err
 	}
 
-	return newClientStream(ctx, id, method, rw, teardown, cc.sourceAddress, cc.destAddress), nil
+	return client.NewStream(
+		ctx,
+		id,
+		method,
+		rw,
+		teardown,
+		cc.sourceAddress,
+		cc.destAddress,
+	), nil
 }
 
 func (cc *ClientConn) asStreamer(

--- a/dialoption.go
+++ b/dialoption.go
@@ -1,8 +1,8 @@
-package client
+package goat
 
 import "google.golang.org/grpc"
 
-// DialOption is an option used when constructing a NewWebsocketClientConn.
+// DialOption is an option used when constructing a NewClientConn.
 type DialOption interface {
 	apply(*ClientConn)
 }

--- a/goat.go
+++ b/goat.go
@@ -6,15 +6,15 @@
 package goat
 
 import (
-	"context"
-
-	wrapped "github.com/avos-io/goat/gen"
+	proto "github.com/avos-io/goat/gen"
+	"github.com/avos-io/goat/types"
 )
+
+// Rpc is the fundamental type in Goat: the generic protobuf structure into
+// which all goat messages are serialised.
+type Rpc = proto.Rpc
 
 // RpcReadWriter is the generic interface used by Goat's client and servers.
 // It utilises the wrapped.Rpc protobuf format for generically wrapping gRPC
 // calls and their metadata.
-type RpcReadWriter interface {
-	Read(context.Context) (*wrapped.Rpc, error)
-	Write(context.Context, *wrapped.Rpc) error
-}
+type RpcReadWriter = types.RpcReadWriter

--- a/goat_test.go
+++ b/goat_test.go
@@ -1,4 +1,4 @@
-// package goat_test contains end-to-end tests
+// package contains end-to-end tests
 package goat_test
 
 import (
@@ -14,11 +14,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/avos-io/goat/client"
+	"github.com/avos-io/goat"
 	"github.com/avos-io/goat/gen/testproto"
 	"github.com/avos-io/goat/gen/testproto/mocks"
 	"github.com/avos-io/goat/internal/testutil"
-	"github.com/avos-io/goat/server"
 )
 
 var errTest = errors.New("TEST ERROR (EXPECTED)")
@@ -442,11 +441,11 @@ func TestUnaryInterceptor(t *testing.T) {
 
 	client, ctx, teardown := setupOpts(
 		service,
-		[]client.DialOption{
-			client.WithUnaryInterceptor(clientInterceptor),
+		[]goat.DialOption{
+			goat.WithUnaryInterceptor(clientInterceptor),
 		},
-		[]server.ServerOption{
-			server.UnaryInterceptor(serverInterceptor),
+		[]goat.ServerOption{
+			goat.UnaryInterceptor(serverInterceptor),
 		},
 	)
 	defer teardown()
@@ -539,13 +538,13 @@ func TestChainUnaryInterceptor(t *testing.T) {
 
 	client, ctx, teardown := setupOpts(
 		service,
-		[]client.DialOption{
-			client.WithUnaryInterceptor(
+		[]goat.DialOption{
+			goat.WithUnaryInterceptor(
 				grpcMiddleware.ChainUnaryClient(clientInterceptors...),
 			),
 		},
-		[]server.ServerOption{
-			server.UnaryInterceptor(
+		[]goat.ServerOption{
+			goat.UnaryInterceptor(
 				grpcMiddleware.ChainUnaryServer(serverInterceptors...),
 			),
 		},
@@ -618,11 +617,11 @@ func TestStreamInterceptor(t *testing.T) {
 
 	client, ctx, teardown := setupOpts(
 		service,
-		[]client.DialOption{
-			client.WithStreamInterceptor(clientInterceptor),
+		[]goat.DialOption{
+			goat.WithStreamInterceptor(clientInterceptor),
 		},
-		[]server.ServerOption{
-			server.StreamInterceptor(serverInterceptor),
+		[]goat.ServerOption{
+			goat.StreamInterceptor(serverInterceptor),
 		},
 	)
 	defer teardown()
@@ -724,13 +723,13 @@ func TestChainStreamInterceptor(t *testing.T) {
 
 	client, ctx, teardown := setupOpts(
 		service,
-		[]client.DialOption{
-			client.WithStreamInterceptor(
+		[]goat.DialOption{
+			goat.WithStreamInterceptor(
 				grpcMiddleware.ChainStreamClient(clientInterceptors...),
 			),
 		},
-		[]server.ServerOption{
-			server.StreamInterceptor(
+		[]goat.ServerOption{
+			goat.StreamInterceptor(
 				grpcMiddleware.ChainStreamServer(serverInterceptors...),
 			),
 		},
@@ -750,8 +749,8 @@ func setup(s testproto.TestServiceServer) (testproto.TestServiceClient, context.
 
 func setupOpts(
 	s testproto.TestServiceServer,
-	clientOpts []client.DialOption,
-	serverOpts []server.ServerOption,
+	clientOpts []goat.DialOption,
+	serverOpts []goat.ServerOption,
 ) (testproto.TestServiceClient, context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -782,7 +781,7 @@ func setupOpts(
 		}
 	}()
 
-	server := server.NewServer("server0", serverOpts...)
+	server := goat.NewServer("server0", serverOpts...)
 	testproto.RegisterTestServiceServer(server, s)
 
 	go func() {
@@ -790,7 +789,7 @@ func setupOpts(
 	}()
 
 	client := testproto.NewTestServiceClient(
-		client.NewClientConn(clientConn, "src", "server0", clientOpts...),
+		goat.NewClientConn(clientConn, "src", "server0", clientOpts...),
 	)
 
 	teardown := func() {

--- a/internal/client/multiplexer.go
+++ b/internal/client/multiplexer.go
@@ -11,14 +11,14 @@ import (
 	"google.golang.org/grpc/encoding/proto"
 	"google.golang.org/grpc/status"
 
-	"github.com/avos-io/goat"
 	wrapped "github.com/avos-io/goat/gen"
 	"github.com/avos-io/goat/internal"
+	"github.com/avos-io/goat/types"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 )
 
 type RpcMultiplexer struct {
-	rw       goat.RpcReadWriter
+	rw       types.RpcReadWriter
 	handlers map[uint64]chan *wrapped.Rpc
 
 	ctx    context.Context
@@ -30,7 +30,7 @@ type RpcMultiplexer struct {
 	codec encoding.Codec
 }
 
-func NewRpcMultiplexer(rw goat.RpcReadWriter) *RpcMultiplexer {
+func NewRpcMultiplexer(rw types.RpcReadWriter) *RpcMultiplexer {
 	rm := &RpcMultiplexer{
 		rw:       rw,
 		handlers: make(map[uint64]chan *wrapped.Rpc),
@@ -95,7 +95,7 @@ func (rm *RpcMultiplexer) CallUnaryMethod(
 // close the stream.
 func (rm *RpcMultiplexer) NewStreamReadWriter(
 	ctx context.Context,
-) (uint64, goat.RpcReadWriter, func()) {
+) (uint64, types.RpcReadWriter, func()) {
 	streamId := atomic.AddUint64(&rm.streamCounter, 1)
 
 	respChan := make(chan *wrapped.Rpc, 1)

--- a/internal/client/multiplexer_test.go
+++ b/internal/client/multiplexer_test.go
@@ -1,7 +1,8 @@
-package client
+package client_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -16,7 +17,10 @@ import (
 	wrapped "github.com/avos-io/goat/gen"
 	"github.com/avos-io/goat/gen/mocks"
 	"github.com/avos-io/goat/gen/testproto"
+	"github.com/avos-io/goat/internal/client"
 )
+
+var errTest = errors.New("TEST ERROR (EXPECTED)")
 
 type testConn struct {
 	mock.Mock
@@ -64,7 +68,7 @@ func makeErrorResponse(id uint64, status *wrapped.ResponseStatus) *wrapped.Rpc {
 func TestUnaryMethodSuccess(t *testing.T) {
 	tc := &testConn{}
 
-	rm := NewRpcMultiplexer(tc)
+	rm := client.NewRpcMultiplexer(tc)
 	defer rm.Close()
 
 	readChan := make(chan readReturn)
@@ -95,7 +99,7 @@ func TestUnaryMethodSuccess(t *testing.T) {
 func TestUnaryMethodFailure(t *testing.T) {
 	tc := &testConn{}
 
-	rm := NewRpcMultiplexer(tc)
+	rm := client.NewRpcMultiplexer(tc)
 	defer rm.Close()
 
 	readChan := make(chan readReturn)
@@ -137,7 +141,7 @@ func TestNewStreamReadWriter(t *testing.T) {
 		unblockRead := make(chan time.Time)
 		rw.EXPECT().Read(mock.Anything).WaitUntil(unblockRead).Return(nil, errTest)
 
-		rm := NewRpcMultiplexer(rw)
+		rm := client.NewRpcMultiplexer(rw)
 		defer rm.Close()
 
 		id, srw, teardown := rm.NewStreamReadWriter(context.Background())
@@ -165,7 +169,7 @@ func TestNewStreamReadWriter(t *testing.T) {
 
 		tc := &testConn{}
 
-		rm := NewRpcMultiplexer(tc)
+		rm := client.NewRpcMultiplexer(tc)
 		defer rm.Close()
 
 		readChan := make(chan readReturn)
@@ -196,7 +200,7 @@ func TestNewStreamReadWriter(t *testing.T) {
 
 		tc := &testConn{}
 
-		rm := NewRpcMultiplexer(tc)
+		rm := client.NewRpcMultiplexer(tc)
 		defer rm.Close()
 
 		readChan := make(chan readReturn)
@@ -230,7 +234,7 @@ func TestNewStreamReadWriter(t *testing.T) {
 
 		tc := &testConn{}
 
-		rm := NewRpcMultiplexer(tc)
+		rm := client.NewRpcMultiplexer(tc)
 		defer rm.Close()
 
 		readChan := make(chan readReturn)
@@ -264,7 +268,7 @@ func TestNewStreamReadWriter(t *testing.T) {
 
 		tc := &testConn{}
 
-		rm := NewRpcMultiplexer(tc)
+		rm := client.NewRpcMultiplexer(tc)
 		defer rm.Close()
 
 		readChan := make(chan readReturn)

--- a/internal/client/stream.go
+++ b/internal/client/stream.go
@@ -15,9 +15,9 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	"github.com/avos-io/goat"
 	wrapped "github.com/avos-io/goat/gen"
 	"github.com/avos-io/goat/internal"
+	"github.com/avos-io/goat/types"
 )
 
 type clientStream struct {
@@ -32,7 +32,7 @@ type clientStream struct {
 	ready  sync.WaitGroup
 	header metadata.MD
 
-	rw goat.RpcReadWriter
+	rw types.RpcReadWriter
 
 	protected struct {
 		sync.Mutex
@@ -51,11 +51,11 @@ type clientStream struct {
 
 var _ grpc.ClientStream = (*clientStream)(nil)
 
-func newClientStream(
+func NewStream(
 	ctx context.Context,
 	id uint64,
 	method string,
-	rw goat.RpcReadWriter,
+	rw types.RpcReadWriter,
 	teardown func(),
 	sourceAddress, destAddress string,
 ) grpc.ClientStream {

--- a/internal/client/stream_test.go
+++ b/internal/client/stream_test.go
@@ -29,7 +29,7 @@ func TestLifecycle(t *testing.T) {
 
 	teardownCalled := make(chan struct{})
 
-	newClientStream(context.Background(), 0, "", rw, func() {
+	NewStream(context.Background(), 0, "", rw, func() {
 		teardownCalled <- struct{}{}
 	}, "src", "dst")
 
@@ -64,7 +64,7 @@ func TestHeader(t *testing.T) {
 			Trailer: &wrapped.Trailer{},
 		}, nil).Once()
 
-		stream := newClientStream(context.Background(), 1, "", rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), 1, "", rw, func() {}, "src", "dst")
 
 		got, err := stream.Header()
 		is.NoError(err)
@@ -80,7 +80,7 @@ func TestHeader(t *testing.T) {
 		rw := mocks.NewRpcReadWriter(t)
 		rw.EXPECT().Read(mock.Anything).Return(nil, errTest)
 
-		stream := newClientStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
 
 		got, err := stream.Header()
 		is.Error(err)
@@ -107,7 +107,7 @@ func TestTrailer(t *testing.T) {
 			Trailer: sent,
 		}, nil)
 
-		stream := newClientStream(context.Background(), 9, "method", rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), 9, "method", rw, func() {}, "src", "dst")
 
 		err := stream.RecvMsg(nil)
 		is.Equal(io.EOF, err)
@@ -127,7 +127,7 @@ func TestTrailer(t *testing.T) {
 			Trailer: &wrapped.Trailer{},
 		}, nil)
 
-		stream := newClientStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
 
 		err := stream.RecvMsg(nil)
 		is.Equal(io.EOF, err)
@@ -144,7 +144,7 @@ func TestCloseSend(t *testing.T) {
 		id := uint64(9001)
 		method := "method"
 
-		stream := newClientStream(context.Background(), id, method, rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), id, method, rw, func() {}, "src", "dst")
 
 		unblockRead := make(chan time.Time)
 		rw.EXPECT().Read(mock.Anything).WaitUntil(unblockRead).Return(nil, errTest).Maybe()
@@ -166,7 +166,7 @@ func TestCloseSend(t *testing.T) {
 		is := require.New(t)
 
 		rw := mocks.NewRpcReadWriter(t)
-		stream := newClientStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
 
 		unblockRead := make(chan time.Time)
 		rw.EXPECT().Read(mock.Anything).WaitUntil(unblockRead).Return(nil, errTest).Maybe()
@@ -180,7 +180,7 @@ func TestContext(t *testing.T) {
 	rw := mocks.NewRpcReadWriter(t)
 	unblockRead := make(chan time.Time)
 	rw.EXPECT().Read(mock.Anything).WaitUntil(unblockRead).Return(nil, errTest).Maybe()
-	stream := newClientStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
+	stream := NewStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
 	require.NotNil(t, stream.Context())
 	unblockRead <- time.Now()
 }
@@ -210,7 +210,7 @@ func TestSendMsg(t *testing.T) {
 			},
 		)).Return(nil)
 
-		stream := newClientStream(context.Background(), id, method, rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), id, method, rw, func() {}, "src", "dst")
 
 		is.NoError(stream.SendMsg(&body))
 		unblockRead <- time.Now()
@@ -224,7 +224,7 @@ func TestSendMsg(t *testing.T) {
 		method := "method"
 
 		teardownCalled := false
-		stream := newClientStream(context.Background(), id, method, rw, func() {
+		stream := NewStream(context.Background(), id, method, rw, func() {
 			teardownCalled = true
 		}, "src", "dst")
 
@@ -250,7 +250,7 @@ func TestSendMsg(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
-		stream := newClientStream(ctx, id, method, rw, func() {}, "src", "dst")
+		stream := NewStream(ctx, id, method, rw, func() {}, "src", "dst")
 
 		// blocks until we get our first response, which will be the err
 		_, _ = stream.Header()
@@ -294,7 +294,7 @@ func TestSendMsg(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
-		stream := newClientStream(ctx, id, method, rw, func() {}, "src", "dst")
+		stream := NewStream(ctx, id, method, rw, func() {}, "src", "dst")
 
 		// blocks until we get our first response, which will be the err
 		_, _ = stream.Header()
@@ -348,7 +348,7 @@ func TestRecvMsg(t *testing.T) {
 		rw.EXPECT().Read(mock.Anything).Return(rpc, nil).Once()
 		rw.EXPECT().Read(mock.Anything).Return(tr, nil)
 
-		stream := newClientStream(context.Background(), 42, "method", rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), 42, "method", rw, func() {}, "src", "dst")
 
 		var got testproto.Msg
 		is.NoError(stream.RecvMsg(&got))
@@ -364,7 +364,7 @@ func TestRecvMsg(t *testing.T) {
 		id := uint64(9001)
 		method := "method"
 
-		stream := newClientStream(context.Background(), id, method, rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), id, method, rw, func() {}, "src", "dst")
 
 		readDone := make(chan struct{})
 		rw.EXPECT().Read(mock.Anything).Return(nil, errTest).Run(
@@ -382,7 +382,7 @@ func TestRecvMsg(t *testing.T) {
 		is := require.New(t)
 
 		rw := mocks.NewRpcReadWriter(t)
-		stream := newClientStream(context.Background(), 42, "method", rw, func() {}, "src", "dst")
+		stream := NewStream(context.Background(), 42, "method", rw, func() {}, "src", "dst")
 
 		recvErr := wrapped.Rpc{
 			Id:     42,

--- a/internal/server/stream.go
+++ b/internal/server/stream.go
@@ -15,9 +15,9 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	"github.com/avos-io/goat"
 	wrapped "github.com/avos-io/goat/gen"
 	"github.com/avos-io/goat/internal"
+	"github.com/avos-io/goat/types"
 )
 
 type serverStream struct {
@@ -27,7 +27,7 @@ type serverStream struct {
 
 	codec encoding.Codec
 
-	rw goat.RpcReadWriter
+	rw types.RpcReadWriter
 
 	protected struct {
 		sync.Mutex
@@ -41,11 +41,11 @@ type serverStream struct {
 
 var _ grpc.ServerStream = (*serverStream)(nil)
 
-func newServerStream(
+func NewServerStream(
 	ctx context.Context,
 	id uint64,
 	method string,
-	rw goat.RpcReadWriter,
+	rw types.RpcReadWriter,
 ) (*serverStream, error) {
 	return &serverStream{
 		ctx:    ctx,

--- a/internal/server/stream_test.go
+++ b/internal/server/stream_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/avos-io/goat/internal"
 )
 
-var errTest = errors.New("EXPECTED TEST ERROR")
+var errTest = errors.New("TEST ERROR (EXPECTED)")
 
 func TestContext(t *testing.T) {
 	is := require.New(t)
@@ -30,7 +30,7 @@ func TestContext(t *testing.T) {
 		metadata.New(map[string]string{"foo": "1"}),
 	)
 	rw := mocks.NewRpcReadWriter(t)
-	stream, err := newServerStream(ctx, 0, "", rw)
+	stream, err := NewServerStream(ctx, 0, "", rw)
 	is.NoError(err)
 	is.Equal(ctx, stream.Context())
 
@@ -51,7 +51,7 @@ func TestHeaders(t *testing.T) {
 		streamId := uint64(9001)
 		method := "my_method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		val := metadata.New(map[string]string{
@@ -77,7 +77,7 @@ func TestHeaders(t *testing.T) {
 		is := require.New(t)
 
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(context.Background(), 0, "", rw)
+		stream, err := NewServerStream(context.Background(), 0, "", rw)
 		is.NoError(err)
 
 		rw.EXPECT().Write(mock.Anything, mock.Anything).Return(errTest)
@@ -91,7 +91,7 @@ func TestHeaders(t *testing.T) {
 		streamId := uint64(9001)
 		method := "my_method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		val1 := metadata.New(map[string]string{"1": "one"})
@@ -136,7 +136,7 @@ func TestHeaders(t *testing.T) {
 		streamId := uint64(9001)
 		method := "my_method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		val := metadata.New(map[string]string{"foo": "bar"})
@@ -179,7 +179,7 @@ func TestHeaders(t *testing.T) {
 		streamId := uint64(9001)
 		method := "my_method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		val := metadata.New(map[string]string{"foo": "bar"})
@@ -208,7 +208,7 @@ func TestTrailers(t *testing.T) {
 		streamId := uint64(9001)
 		method := "my_method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		tr1 := metadata.New(map[string]string{"1": "one"})
@@ -246,7 +246,7 @@ func TestTrailers(t *testing.T) {
 		streamId := uint64(9001)
 		method := "my_method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		tr := metadata.New(map[string]string{"1": "one"})
@@ -272,7 +272,7 @@ func TestTrailers(t *testing.T) {
 		streamId := uint64(9001)
 		method := "my_method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		tr := metadata.New(map[string]string{"1": "one"})
@@ -291,7 +291,7 @@ func TestSendMsg(t *testing.T) {
 		streamId := uint64(9001)
 		method := "my_method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		codec := encoding.GetCodec(proto.Name)
@@ -317,7 +317,7 @@ func TestSendMsg(t *testing.T) {
 		streamId := uint64(9001)
 		method := "my_method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		rw.EXPECT().Write(ctx, mock.Anything).Return(errTest)
@@ -334,7 +334,7 @@ func TestRecvMsg(t *testing.T) {
 		streamId := uint64(9001)
 		method := "method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		codec := encoding.GetCodec(proto.Name)
@@ -372,7 +372,7 @@ func TestRecvMsg(t *testing.T) {
 		streamId := uint64(9001)
 		method := "method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		rw.EXPECT().Read(ctx).Return(nil, errTest)
@@ -388,7 +388,7 @@ func TestRecvMsg(t *testing.T) {
 		streamId := uint64(9001)
 		method := "method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		rpc := wrapped.Rpc{
@@ -416,7 +416,7 @@ func TestRecvMsg(t *testing.T) {
 		streamId := uint64(9001)
 		method := "method"
 		rw := mocks.NewRpcReadWriter(t)
-		stream, err := newServerStream(ctx, streamId, method, rw)
+		stream, err := NewServerStream(ctx, streamId, method, rw)
 		is.NoError(err)
 
 		rpc := wrapped.Rpc{

--- a/internal/server/transport_stream.go
+++ b/internal/server/transport_stream.go
@@ -26,7 +26,7 @@ type unaryServerTransportStream struct {
 
 var _ grpc.ServerTransportStream = (*unaryServerTransportStream)(nil)
 
-func newUnaryServerTransportStream(name string) *unaryServerTransportStream {
+func NewUnaryServerTransportStream(name string) *unaryServerTransportStream {
 	return &unaryServerTransportStream{fullMethod: name}
 }
 
@@ -108,7 +108,7 @@ type serverTransportStream struct {
 
 var _ grpc.ServerTransportStream = (*serverTransportStream)(nil)
 
-func newServerTransportStream(
+func NewServerTransportStream(
 	fullMethod string,
 	stream grpc.ServerStream,
 ) *serverTransportStream {

--- a/internal/server/transport_stream_test.go
+++ b/internal/server/transport_stream_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestUnaryTransportStream(t *testing.T) {
 	t.Run("Method", func(t *testing.T) {
-		ts := newUnaryServerTransportStream("foo")
+		ts := NewUnaryServerTransportStream("foo")
 		require.Equal(t, "foo", ts.Method())
 	})
 
 	t.Run("Headers", func(t *testing.T) {
 		is := require.New(t)
 
-		ts := newUnaryServerTransportStream("")
+		ts := NewUnaryServerTransportStream("")
 		md1 := metadata.New(map[string]string{"foo": "1"})
 		md2 := metadata.New(map[string]string{"foo": "2"})
 		md3 := metadata.New(map[string]string{"foo": "2"})
@@ -38,7 +38,7 @@ func TestUnaryTransportStream(t *testing.T) {
 	t.Run("Trailers", func(t *testing.T) {
 		is := require.New(t)
 
-		ts := newUnaryServerTransportStream("")
+		ts := NewUnaryServerTransportStream("")
 		md1 := metadata.New(map[string]string{"foo": "1"})
 		md2 := metadata.New(map[string]string{"foo": "2"})
 
@@ -52,7 +52,7 @@ func TestUnaryTransportStream(t *testing.T) {
 
 func TestServerTransportStream(t *testing.T) {
 	t.Run("Method", func(t *testing.T) {
-		ts := newServerTransportStream("foo", mocks.NewTestService_BidiStreamServer(t))
+		ts := NewServerTransportStream("foo", mocks.NewTestService_BidiStreamServer(t))
 		require.Equal(t, "foo", ts.Method())
 	})
 
@@ -62,7 +62,7 @@ func TestServerTransportStream(t *testing.T) {
 		md := metadata.New(map[string]string{"foo": "1"})
 
 		m := mocks.NewTestService_BidiStreamServer(t)
-		ts := newServerTransportStream("", m)
+		ts := NewServerTransportStream("", m)
 
 		m.EXPECT().SetHeader(md).Return(nil).Once()
 		is.NoError(ts.SetHeader(md))

--- a/internal/testutil/pipe.go
+++ b/internal/testutil/pipe.go
@@ -1,4 +1,4 @@
-package e2e
+package testutil
 
 import (
 	"context"

--- a/internal/util.go
+++ b/internal/util.go
@@ -7,8 +7,8 @@ import (
 
 	"google.golang.org/grpc/metadata"
 
-	"github.com/avos-io/goat"
 	wrapped "github.com/avos-io/goat/gen"
+	"github.com/avos-io/goat/types"
 )
 
 func ToKeyValue(mds ...metadata.MD) []*wrapped.KeyValue {
@@ -49,7 +49,7 @@ func ToMetadata(kvs []*wrapped.KeyValue) (metadata.MD, error) {
 func NewFnReadWriter(
 	r func(context.Context) (*wrapped.Rpc, error),
 	w func(context.Context, *wrapped.Rpc) error,
-) goat.RpcReadWriter {
+) types.RpcReadWriter {
 	return &fnReadWriter{r, w}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -1,18 +1,17 @@
-package e2e
+package goat
 
 import (
 	"context"
 	"log"
 	"sync"
 
-	"github.com/avos-io/goat"
 	wrapped "github.com/avos-io/goat/gen"
 )
 
 // Is free to modify the passed in header, e.g. changing the Destination.
 // If an error is returned, the RPC is dropped.
 type RpcIntercepter func(hdr *wrapped.RequestHeader) error
-type NewConnection func(id string) (goat.RpcReadWriter, error)
+type NewConnection func(id string) (RpcReadWriter, error)
 type ClientDisconnect func(id string, reason error)
 
 type proxy struct {
@@ -34,7 +33,7 @@ type command struct {
 
 type proxyClient struct {
 	id         string
-	conn       goat.RpcReadWriter
+	conn       RpcReadWriter
 	toServer   chan command
 	fromServer chan *wrapped.Rpc
 }
@@ -55,7 +54,7 @@ func NewProxy(
 	}
 }
 
-func (p *proxy) AddClient(id string, conn goat.RpcReadWriter) {
+func (p *proxy) AddClient(id string, conn RpcReadWriter) {
 	client := &proxyClient{
 		id:         id,
 		conn:       conn,

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
-package server
+package goat
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/avos-io/goat/gen/testproto/mocks"
 	"github.com/avos-io/goat/internal/testutil"
 )
+
+var errTest = errors.New("TEST ERROR (EXPECTED)")
 
 func TestNew(t *testing.T) {
 	new := NewServer("s0")

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"context"
+
+	wrapped "github.com/avos-io/goat/gen"
+)
+
+// RpcReadWriter is the generic interface used by Goat's client and servers.
+// It utilises the wrapped.Rpc protobuf format for generically wrapping gRPC
+// calls and their metadata.
+type RpcReadWriter interface {
+	Read(context.Context) (*wrapped.Rpc, error)
+	Write(context.Context, *wrapped.Rpc) error
+}

--- a/websocket.go
+++ b/websocket.go
@@ -1,10 +1,9 @@
-package e2e
+package goat
 
 import (
 	"context"
 	"errors"
 
-	"github.com/avos-io/goat"
 	wrapped "github.com/avos-io/goat/gen"
 	"google.golang.org/protobuf/proto"
 	"nhooyr.io/websocket"
@@ -16,7 +15,7 @@ type goatOverWebsocket struct {
 	conn *websocket.Conn
 }
 
-func NewGoatOverWebsocket(ws *websocket.Conn) goat.RpcReadWriter {
+func NewGoatOverWebsocket(ws *websocket.Conn) RpcReadWriter {
 	return &goatOverWebsocket{ws}
 }
 


### PR DESCRIPTION
Move the public interface (Server, Client, Interceptors, DialOptions, Proxy) into the top level `goat` package, splitting out implementation details into `internal/client` and `internal/server`. This means that users of the goat stuff can import everything they need from `github.com/avos-io/goat`, rather than having to use e.g., `github.com/avos-io/goat/client`.