### PR TITLE
Use a mockery config file + newer version

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,3 +1,14 @@
 # yaml
 with-expecter: True
-case: snake
+all: true
+
+packages:
+  github.com/avos-io/goat/types: 
+    config:
+      dir: "gen/mocks"
+      outpkg: "mocks"
+  github.com/avos-io/goat/gen/testproto:
+    config:
+      dir: "gen/testproto/mocks"
+      outpkg: "mocks"
+  

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,6 +2,9 @@ version: '3'
 method: timestamp
 run: once
 
+vars:
+  MOCKERY: github.com/vektra/mockery/v2@v2.34.2
+
 tasks:
   default:
     deps: [test]
@@ -50,11 +53,12 @@ tasks:
   gen-mocks:
     deps: [gen-proto]
     cmds:
-      - mockery --name "RpcReadWriter" --dir types --output ./gen/mocks
-      - mockery --dir ./gen/testproto --output ./gen/testproto/mocks --all --keeptree
+      - go run {{.MOCKERY}} --log-level=warn
+      - touch gen/mockery.stamp
     sources:
-      - "pkg/**/*.go"
+      - "internal/*/*.go"
       - "goat.go"
+      - ".mockery.yml"
     generates:
-      - gen/mocks/**/*.go
+      - gen/mockery.stamp
 

--- a/goat_test.go
+++ b/goat_test.go
@@ -29,7 +29,7 @@ func TestUnary(t *testing.T) {
 		send := &testproto.Msg{Value: 42}
 		exp := &testproto.Msg{Value: 9001}
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().Unary(mock.Anything, mock.MatchedBy(
 			func(msg *testproto.Msg) bool {
 				return msg.GetValue() == send.GetValue()
@@ -48,7 +48,7 @@ func TestUnary(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		is := require.New(t)
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().Unary(mock.Anything, mock.Anything).Return(nil, errTest)
 
 		client, ctx, teardown := setup(service)
@@ -64,7 +64,7 @@ func TestUnary(t *testing.T) {
 
 		exp := &testproto.Msg{Value: 9001}
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().Unary(mock.Anything, mock.Anything).Return(exp, errTest)
 
 		client, ctx, teardown := setup(service)
@@ -82,7 +82,7 @@ func TestServerStream(t *testing.T) {
 
 		sent := &testproto.Msg{Value: 10}
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().ServerStream(mock.Anything, mock.Anything).
 			Run(
 				func(msg *testproto.Msg, stream testproto.TestService_ServerStreamServer) {
@@ -117,7 +117,7 @@ func TestServerStream(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		is := require.New(t)
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().ServerStream(mock.Anything, mock.Anything).Return(errTest)
 
 		client, ctx, teardown := setup(service)
@@ -144,7 +144,7 @@ func TestClientStream(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		is := require.New(t)
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().ClientStream(mock.Anything).
 			Run(func(stream testproto.TestService_ClientStreamServer) {
 				sum := int32(0)
@@ -182,7 +182,7 @@ func TestClientStream(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		is := require.New(t)
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().ClientStream(mock.Anything).Return(errTest)
 
 		client, ctx, teardown := setup(service)
@@ -202,7 +202,7 @@ func TestBidiStream(t *testing.T) {
 	t.Run("OK: client messages first", func(t *testing.T) {
 		is := require.New(t)
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().BidiStream(mock.Anything).
 			Run(
 				func(stream testproto.TestService_BidiStreamServer) {
@@ -238,7 +238,7 @@ func TestBidiStream(t *testing.T) {
 	t.Run("OK: server messages first", func(t *testing.T) {
 		is := require.New(t)
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().BidiStream(mock.Anything).
 			Run(
 				func(stream testproto.TestService_BidiStreamServer) {
@@ -276,7 +276,7 @@ func TestBidiStream(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		is := require.New(t)
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().BidiStream(mock.Anything).Return(errTest)
 
 		client, ctx, teardown := setup(service)
@@ -297,7 +297,7 @@ func TestStreamHeaders(t *testing.T) {
 	t.Run("Headers sent with SendHeader", func(t *testing.T) {
 		is := require.New(t)
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().BidiStream(mock.Anything).
 			Run(
 				func(stream testproto.TestService_BidiStreamServer) {
@@ -336,7 +336,7 @@ func TestStreamHeaders(t *testing.T) {
 	t.Run("Headers sent on first message", func(t *testing.T) {
 		is := require.New(t)
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().BidiStream(mock.Anything).
 			Run(
 				func(stream testproto.TestService_BidiStreamServer) {
@@ -372,7 +372,7 @@ func TestStreamHeaders(t *testing.T) {
 func TestStreamTrailers(t *testing.T) {
 	is := require.New(t)
 
-	service := mocks.NewTestServiceServer(t)
+	service := mocks.NewMockTestServiceServer(t)
 	service.EXPECT().ClientStream(mock.Anything).
 		Run(func(stream testproto.TestService_ClientStreamServer) {
 			md := metadata.New(map[string]string{"foo": "bar"})
@@ -437,7 +437,7 @@ func TestUnaryInterceptor(t *testing.T) {
 		return handler(newCtx, req)
 	}
 
-	service := mocks.NewTestServiceServer(t)
+	service := mocks.NewMockTestServiceServer(t)
 	service.EXPECT().Unary(mock.Anything, mock.Anything).
 		Run(func(ctx context.Context, msg *testproto.Msg) {
 			md, ok := metadata.FromIncomingContext(ctx)
@@ -532,7 +532,7 @@ func TestChainUnaryInterceptor(t *testing.T) {
 		serverInterceptors = append(serverInterceptors, makeServerInterceptor(k, v))
 	}
 
-	service := mocks.NewTestServiceServer(t)
+	service := mocks.NewMockTestServiceServer(t)
 	service.EXPECT().Unary(mock.Anything, mock.Anything).
 		Run(func(ctx context.Context, msg *testproto.Msg) {
 			md, ok := metadata.FromIncomingContext(ctx)
@@ -611,7 +611,7 @@ func TestStreamInterceptor(t *testing.T) {
 		})
 	}
 
-	service := mocks.NewTestServiceServer(t)
+	service := mocks.NewMockTestServiceServer(t)
 	service.EXPECT().ServerStream(mock.Anything, mock.Anything).
 		Run(func(_ *testproto.Msg, stream testproto.TestService_ServerStreamServer) {
 			md, ok := metadata.FromIncomingContext(stream.Context())
@@ -715,7 +715,7 @@ func TestChainStreamInterceptor(t *testing.T) {
 		serverInterceptors = append(serverInterceptors, makeServerInterceptor(k, v))
 	}
 
-	service := mocks.NewTestServiceServer(t)
+	service := mocks.NewMockTestServiceServer(t)
 	service.EXPECT().ServerStream(mock.Anything, mock.Anything).
 		Run(func(_ *testproto.Msg, stream testproto.TestService_ServerStreamServer) {
 			md, ok := metadata.FromIncomingContext(stream.Context())

--- a/internal/client/multiplexer_test.go
+++ b/internal/client/multiplexer_test.go
@@ -176,7 +176,7 @@ func TestUnaryMethodFailureDespiteBody(t *testing.T) {
 func TestUnaryMethodFailureChannelClosed(t *testing.T) {
 	// Make sure we properly handle the case where our IO disconnects while we're
 	// waiting on a reply to a unary Rpc.
-	rw := mocks.NewRpcReadWriter(t)
+	rw := mocks.NewMockRpcReadWriter(t)
 
 	rm := client.NewRpcMultiplexer(rw)
 	defer rm.Close()
@@ -204,7 +204,7 @@ func TestUnaryMethodFailureChannelClosed(t *testing.T) {
 
 func TestNewStreamReadWriter(t *testing.T) {
 	t.Run("Write", func(t *testing.T) {
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 
 		unblockRead := make(chan time.Time)
 		rw.EXPECT().Read(mock.Anything).WaitUntil(unblockRead).Return(nil, errTest)

--- a/internal/client/stream_test.go
+++ b/internal/client/stream_test.go
@@ -24,7 +24,7 @@ import (
 var errTest = errors.New("EXPECTED TEST ERROR")
 
 func TestLifecycle(t *testing.T) {
-	rw := mocks.NewRpcReadWriter(t)
+	rw := mocks.NewMockRpcReadWriter(t)
 	rw.EXPECT().Read(mock.Anything).Return(nil, errTest)
 
 	teardownCalled := make(chan struct{})
@@ -53,7 +53,7 @@ func TestHeader(t *testing.T) {
 			},
 		}
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		rw.EXPECT().Read(mock.Anything).Return(&goatorepo.Rpc{
 			Id:     1,
 			Header: sent,
@@ -77,7 +77,7 @@ func TestHeader(t *testing.T) {
 	t.Run("Read err", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		rw.EXPECT().Read(mock.Anything).Return(nil, errTest)
 
 		stream := NewStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
@@ -100,7 +100,7 @@ func TestTrailer(t *testing.T) {
 			},
 		}
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		rw.EXPECT().Read(mock.Anything).Return(&goatorepo.Rpc{
 			Id:      9,
 			Header:  &goatorepo.RequestHeader{Method: "method"},
@@ -120,7 +120,7 @@ func TestTrailer(t *testing.T) {
 	t.Run("No metadata", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		rw.EXPECT().Read(mock.Anything).Return(&goatorepo.Rpc{
 			Id:      9001,
 			Header:  &goatorepo.RequestHeader{Method: "my_method"},
@@ -140,7 +140,7 @@ func TestCloseSend(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		id := uint64(9001)
 		method := "method"
 
@@ -165,7 +165,7 @@ func TestCloseSend(t *testing.T) {
 	t.Run("Write err", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream := NewStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
 
 		unblockRead := make(chan time.Time)
@@ -177,7 +177,7 @@ func TestCloseSend(t *testing.T) {
 }
 
 func TestContext(t *testing.T) {
-	rw := mocks.NewRpcReadWriter(t)
+	rw := mocks.NewMockRpcReadWriter(t)
 	unblockRead := make(chan time.Time)
 	rw.EXPECT().Read(mock.Anything).WaitUntil(unblockRead).Return(nil, errTest).Maybe()
 	stream := NewStream(context.Background(), 0, "", rw, func() {}, "src", "dst")
@@ -189,7 +189,7 @@ func TestSendMsg(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		id := uint64(9001)
 		method := "method"
 
@@ -219,7 +219,7 @@ func TestSendMsg(t *testing.T) {
 	t.Run("Write err", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		id := uint64(9001)
 		method := "method"
 
@@ -240,7 +240,7 @@ func TestSendMsg(t *testing.T) {
 	})
 
 	t.Run("Write picks up loop read err", func(t *testing.T) {
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		id := uint64(9001)
 		method := "method"
 
@@ -274,7 +274,7 @@ func TestSendMsg(t *testing.T) {
 	})
 
 	t.Run("Write picks up recvd error", func(t *testing.T) {
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		id := uint64(9001)
 		method := "method"
 
@@ -322,7 +322,7 @@ func TestRecvMsg(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 
 		msg := testproto.Msg{Value: 9001}
 		msgBytes, err := encoding.GetCodec(proto.Name).Marshal(&msg)
@@ -360,7 +360,7 @@ func TestRecvMsg(t *testing.T) {
 	t.Run("RecvMsg picks up loop read err", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		id := uint64(9001)
 		method := "method"
 
@@ -381,7 +381,7 @@ func TestRecvMsg(t *testing.T) {
 	t.Run("RecvMsg picks up error", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream := NewStream(context.Background(), 42, "method", rw, func() {}, "src", "dst")
 
 		recvErr := goatorepo.Rpc{

--- a/internal/server/stream_test.go
+++ b/internal/server/stream_test.go
@@ -29,7 +29,7 @@ func TestContext(t *testing.T) {
 		context.Background(),
 		metadata.New(map[string]string{"foo": "1"}),
 	)
-	rw := mocks.NewRpcReadWriter(t)
+	rw := mocks.NewMockRpcReadWriter(t)
 	stream, err := NewServerStream(ctx, 0, "", "", "", rw)
 	is.NoError(err)
 	is.Equal(ctx, stream.Context())
@@ -52,7 +52,7 @@ func TestHeaders(t *testing.T) {
 		method := "my_method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -80,7 +80,7 @@ func TestHeaders(t *testing.T) {
 	t.Run("SendHeader write error", func(t *testing.T) {
 		is := require.New(t)
 
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(context.Background(), 0, "", "", "", rw)
 		is.NoError(err)
 
@@ -96,7 +96,7 @@ func TestHeaders(t *testing.T) {
 		method := "my_method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -145,7 +145,7 @@ func TestHeaders(t *testing.T) {
 		method := "my_method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -194,7 +194,7 @@ func TestHeaders(t *testing.T) {
 		method := "my_method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -227,7 +227,7 @@ func TestTrailers(t *testing.T) {
 		method := "my_method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -269,7 +269,7 @@ func TestTrailers(t *testing.T) {
 		method := "my_method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -299,7 +299,7 @@ func TestTrailers(t *testing.T) {
 		method := "my_method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -320,7 +320,7 @@ func TestSendMsg(t *testing.T) {
 		method := "my_method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -350,7 +350,7 @@ func TestSendMsg(t *testing.T) {
 		method := "my_method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -369,7 +369,7 @@ func TestRecvMsg(t *testing.T) {
 		method := "method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -411,7 +411,7 @@ func TestRecvMsg(t *testing.T) {
 		method := "method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -429,7 +429,7 @@ func TestRecvMsg(t *testing.T) {
 		method := "method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 
@@ -461,7 +461,7 @@ func TestRecvMsg(t *testing.T) {
 		method := "method"
 		source := "my_source"
 		destination := "my_dest"
-		rw := mocks.NewRpcReadWriter(t)
+		rw := mocks.NewMockRpcReadWriter(t)
 		stream, err := NewServerStream(ctx, streamId, method, source, destination, rw)
 		is.NoError(err)
 

--- a/internal/server/transport_stream_test.go
+++ b/internal/server/transport_stream_test.go
@@ -52,7 +52,7 @@ func TestUnaryTransportStream(t *testing.T) {
 
 func TestServerTransportStream(t *testing.T) {
 	t.Run("Method", func(t *testing.T) {
-		ts := NewServerTransportStream("foo", mocks.NewTestService_BidiStreamServer(t))
+		ts := NewServerTransportStream("foo", mocks.NewMockTestService_BidiStreamServer(t))
 		require.Equal(t, "foo", ts.Method())
 	})
 
@@ -61,7 +61,7 @@ func TestServerTransportStream(t *testing.T) {
 
 		md := metadata.New(map[string]string{"foo": "1"})
 
-		m := mocks.NewTestService_BidiStreamServer(t)
+		m := mocks.NewMockTestService_BidiStreamServer(t)
 		ts := NewServerTransportStream("", m)
 
 		m.EXPECT().SetHeader(md).Return(nil).Once()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -419,7 +419,7 @@ func TestReadErrorClosesBothLoops(t *testing.T) {
 
 	doneChannel := make(chan struct{})
 
-	client1Rw := mocks.NewRpcReadWriter(t)
+	client1Rw := mocks.NewMockRpcReadWriter(t)
 	client1Rw.EXPECT().Write(mock.Anything, mock.Anything).Return(errors.New("error"))
 	client1Rw.EXPECT().Read(mock.Anything).Run(func(ctx context.Context) {
 		<-ctx.Done()

--- a/server_test.go
+++ b/server_test.go
@@ -53,7 +53,7 @@ func TestUnary(t *testing.T) {
 		sent := testproto.Msg{Value: 42}
 		exp := testproto.Msg{Value: 43}
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().Unary(mock.Anything, mock.MatchedBy(
 			func(m *testproto.Msg) bool {
 				return m.Value == sent.Value
@@ -92,7 +92,7 @@ func TestUnary(t *testing.T) {
 		method := "/" + testproto.TestService_ServiceDesc.ServiceName + "/Unary"
 		sent := testproto.Msg{Value: 42}
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().Unary(mock.Anything, mock.MatchedBy(
 			func(m *testproto.Msg) bool {
 				return m.Value == sent.Value
@@ -137,7 +137,7 @@ func TestServerStream(t *testing.T) {
 			expected[i] = &testproto.Msg{Value: int32(i + 1)}
 		}
 
-		service := mocks.NewTestServiceServer(t)
+		service := mocks.NewMockTestServiceServer(t)
 		service.EXPECT().ServerStream(mock.Anything, mock.Anything).
 			Run(
 				func(m *testproto.Msg, stream testproto.TestService_ServerStreamServer) {
@@ -219,7 +219,7 @@ func TestServerStream(t *testing.T) {
 
 		srv := NewServer(dst)
 		defer srv.Stop()
-		testproto.RegisterTestServiceServer(srv, mocks.NewTestServiceServer(t))
+		testproto.RegisterTestServiceServer(srv, mocks.NewMockTestServiceServer(t))
 		conn := testutil.NewTestConn()
 
 		go func() {


### PR DESCRIPTION
Moves us to a somewhat more idiomatic usage of mockery. It's at least mostly consistent with Iona now.

Parent PR: https://github.com/avos-io/iona/pull/2589