### PR TITLE
Fix gen-proto running every time

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,7 +52,8 @@ tasks:
       - touch gen/proto.touch
     generates:
       - gen/proto.touch
-
+    sources:
+      - "**/*.proto"
   gen-mocks:
     deps: [gen-proto]
     cmds:
@@ -64,4 +65,3 @@ tasks:
       - ".mockery.yml"
     generates:
       - gen/mockery.stamp
-


### PR DESCRIPTION
Fix for task gen-proto and similar running every time. Previously `task gen && task gen` would run the task twice, now it runs only once.