### PR TITLE
A couple of fixes around logging

### DIFF
--- a/internal/server/stream.go
+++ b/internal/server/stream.go
@@ -316,7 +316,6 @@ func (ss *serverStream) SendTrailer(trErr error) error {
 
 	err := ss.rw.Write(ss.ctx, &tr)
 	if err != nil {
-		log.Error().Err(err).Msg("ServerStream SendTrailer: conn.Write")
 		return err
 	}
 	return nil

--- a/server.go
+++ b/server.go
@@ -446,7 +446,9 @@ func (h *handler) processStreamingRpc(
 
 	ctx, cancel, err := contextFromHeaders(clientCtx, rpc.GetHeader())
 	if err != nil {
-		log.Panic().Err(err).Msg("Server: failed to get context from headers")
+		log.Info().Msgf("invalid headers: calling RST stream %d", rpc.Id)
+		h.resetStream(rpc)
+		return nil
 	}
 
 	streamId := rpc.Id
@@ -532,7 +534,6 @@ func (h *handler) runStream(
 
 	err = stream.SendTrailer(appErr)
 	if err != nil {
-		log.Error().Err(err).Msg("Server: SendTrailer")
 		return err
 	}
 


### PR DESCRIPTION
1. Don't log if SentTrailer() fails. This can quite reasonably fail if
   for example the RPC has been cancelled. Maybe the client has aborted
   a streaming RPC; in such a case the context is cancelled and we don't
   want the GOAT library spamming the log in such a case.

2. Unrelated, but I noticed a case where GOAT might panic on invalid
   input from a client. That's no good! If we get an invalid header on
   a streaming RPC, don't panic, just drop the RPC and log it.