### PR TITLE
An RPC with a nil body would produce a seg fault.

### DIFF
--- a/internal/server/stream.go
+++ b/internal/server/stream.go
@@ -248,7 +248,7 @@ func (ss *serverStream) RecvMsg(m interface{}) error {
 				RecvTime: time.Now(),
 				Payload:  m,
 				Length:   len(rpc.GetBody().GetData()),
-				Data:     rpc.GetBody().Data,
+				Data:     rpc.GetBody().GetData(),
 			})
 		}
 	}


### PR DESCRIPTION
Fix this, with unit test.
