### PR TITLE
Fix websocket library deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ See [Client](#client) below on how to use a GOAT client. See [Server](#server) b
 ### Transports
 
 A _transport implementation_ is one implementing this interface; two example implementations exist in this repo:
-* A simple websocket-based tranport in `NewGoatOverWebsocket()`. This allows creating a new GOAT transport given a websocket connection from the [nhooyr.io/websocket](https://nhooyr.io/websocket) Golang module.
+* A simple websocket-based tranport in `NewGoatOverWebsocket()`. This allows creating a new GOAT transport given a websocket connection from the [github.com/coder/websocket](https://pkg.go.dev/github.com/coder/websocket) Golang module.
 * The unit testing code has several transport implementations, e.g. `NewGoatOverPipe()` which works over any `net.Conn` including those returned by [net.Pipe()](https://pkg.go.dev/net#Pipe).
-* An example transport over HTTP 1/1.1 in `NewGoatOverHttp()`. You probably don't want to use this, but it serves as another example of implementing a transport.
+* An example transport over HTTP 1/1.1 in `NewGoatOverHttp()`. You probably don't want to use this, but it serves as another example of implementing a transport.le transport over HTTP 1/1.1 in `NewGoatOverHttp()`. You probably don't want to use this, but it serves as another example of implementing a transport.
 
 ### Client and server names
 
@@ -127,7 +127,7 @@ pb.RegisterRouteGuideServer(grpcServer, newServer())
 grpcServer.Serve(lis)
 ```
 
-Rather than `grpc.NewServer()` we use `goat.NewServer()`. 
+Rather than `grpc.NewServer()` we use `goat.NewServer()`.
 
 ```go
 // ...
@@ -146,7 +146,7 @@ This is an advanced feature and not yet documented. It is recommended to read th
 
 # Protocol
 
-GRPC is canonically [transported over HTTP/2](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md), making use of HTTP/2's ability to provide framing and stream management. 
+GRPC is canonically [transported over HTTP/2](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md), making use of HTTP/2's ability to provide framing and stream management.
 
 Three concepts from HTTP/2 are core to understanding GRPC's use there (we're glossing over detail like `CONTINUATION` frames and more; the following suffices):
 1. `HEADERS` frames

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [Client](#client) below on how to use a GOAT client. See [Server](#server) b
 A _transport implementation_ is one implementing this interface; two example implementations exist in this repo:
 * A simple websocket-based tranport in `NewGoatOverWebsocket()`. This allows creating a new GOAT transport given a websocket connection from the [github.com/coder/websocket](https://pkg.go.dev/github.com/coder/websocket) Golang module.
 * The unit testing code has several transport implementations, e.g. `NewGoatOverPipe()` which works over any `net.Conn` including those returned by [net.Pipe()](https://pkg.go.dev/net#Pipe).
-* An example transport over HTTP 1/1.1 in `NewGoatOverHttp()`. You probably don't want to use this, but it serves as another example of implementing a transport.le transport over HTTP 1/1.1 in `NewGoatOverHttp()`. You probably don't want to use this, but it serves as another example of implementing a transport.
+* An example transport over HTTP 1/1.1 in `NewGoatOverHttp()`. You probably don't want to use this, but it serves as another example of implementing a transport.
 
 ### Client and server names
 

--- a/cmd/e2e-websocket-test/main.go
+++ b/cmd/e2e-websocket-test/main.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/avos-io/goat"
 	"github.com/avos-io/goat/gen/testproto"
+	"github.com/coder/websocket"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-	"nhooyr.io/websocket"
 )
 
 type myClientIden string

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/avos-io/goat
 go 1.19
 
 require (
+	github.com/coder/websocket v1.8.12
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/jonboulle/clockwork v0.4.0
 	github.com/rs/zerolog v1.28.0
@@ -11,7 +12,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.3
 	google.golang.org/protobuf v1.33.0
-	nhooyr.io/websocket v1.8.10
 )
 
 require github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -138,5 +140,3 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-nhooyr.io/websocket v1.8.10 h1:mv4p+MnGrLDcPlBoWsvPP7XCzTYMXP9F9eIGoKbgx7Q=
-nhooyr.io/websocket v1.8.10/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/avos-io/goat/gen/mocks"
 	"github.com/avos-io/goat/gen/testproto"
 	"github.com/avos-io/goat/internal/testutil"
+	"github.com/coder/websocket"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"nhooyr.io/websocket"
 )
 
 type simulatedServer struct {

--- a/websocket.go
+++ b/websocket.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 
 	"github.com/avos-io/goat/gen/goatorepo"
+	"github.com/coder/websocket"
 	"google.golang.org/protobuf/proto"
-	"nhooyr.io/websocket"
 )
 
 var errNonBinaryWebsocketMessage = errors.New("invalid websocket message: not binary")


### PR DESCRIPTION
nhooyr.io/websocket has been deprecated. The same repo is now maintained by [github.com/coder/websocket](https://pkg.go.dev/github.com/coder/websocket).

nhooyr.io/websocket is now as a consequence deprecated, so this change moves from nhooyr to coder websocket.