### PR TITLE
workflow for go module tidiness check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,8 +74,8 @@ jobs:
         run: |
           go mod tidy
           if [[ -n $(git status --porcelain go.mod go.sum) ]]; then
-          echo "::error::Changes detected in go.mod or go.sum after `go mod tidy`"
-          echo "::error::Please run `go mod tidy` and commit the changes, a diff is shown below:"
+          echo "::error::Changes detected in go.mod or go.sum after 'go mod tidy'"
+          echo "::error::Please run 'go mod tidy' and commit the changes, a diff is shown below:"
           git diff go.mod go.sum
           exit 1
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,3 +68,15 @@ jobs:
           cd ../goat-es
           E2E_TEST_ADDR=ws://localhost:9043/test npm run test:integration
           kill %1
+
+      - name: Check that go modules are tidy
+        working-directory: goat
+        run: |
+          cd backend
+          go mod tidy
+          if [[ -n $(git status --porcelain go.mod go.sum) ]]; then
+          echo "::error::Changes detected in go.mod or go.sum after `go mod tidy`"
+          echo "::error::Please run `go mod tidy` and commit the changes, a diff is shown below:"
+          git diff go.mod go.sum
+          exit 1
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,6 @@ jobs:
       - name: Check that go modules are tidy
         working-directory: goat
         run: |
-          cd backend
           go mod tidy
           if [[ -n $(git status --porcelain go.mod go.sum) ]]; then
           echo "::error::Changes detected in go.mod or go.sum after `go mod tidy`"

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/coder/websocket v1.8.12
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/jonboulle/clockwork v0.4.0
+	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sync v0.8.0
@@ -16,16 +17,14 @@ require (
 	google.golang.org/protobuf v1.34.2
 )
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
This PR adds a GitHub workflow step which fails if a `go mod tidy` has not been run (but should have been) on the code you are committing.