### PR TITLE
Fix head of line blocking bug when the underlying connection has errors in streaming RPC

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"sync"
 
 	goatorepo "github.com/avos-io/goat/gen/goatorepo"
 )
@@ -9,6 +10,12 @@ import (
 type TestConn struct {
 	ReadChan  chan ReadReturn
 	WriteChan chan *goatorepo.Rpc
+	ErrorChan chan error
+
+	error   error
+	readers int
+	writers int
+	lock    sync.Mutex
 }
 
 type ReadReturn struct {
@@ -20,24 +27,70 @@ func NewTestConn() *TestConn {
 	conn := TestConn{
 		ReadChan:  make(chan ReadReturn),
 		WriteChan: make(chan *goatorepo.Rpc),
+		ErrorChan: make(chan error, 2),
 	}
 	return &conn
 }
 
 func (c *TestConn) Read(ctx context.Context) (*goatorepo.Rpc, error) {
+	c.lock.Lock()
+	c.readers++
+	err := c.error
+	c.lock.Unlock()
+	defer func() { c.lock.Lock(); c.readers--; c.lock.Unlock() }()
+
+	if err != nil {
+		return nil, err
+	}
+
 	select {
 	case rr := <-c.ReadChan:
 		return rr.Rpc, rr.Err
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	case err := <-c.ErrorChan:
+		return nil, err
 	}
 }
 
 func (c *TestConn) Write(ctx context.Context, rpc *goatorepo.Rpc) error {
+	c.lock.Lock()
+	c.writers++
+	err := c.error
+	c.lock.Unlock()
+	defer func() { c.lock.Lock(); c.writers--; c.lock.Unlock() }()
+
+	if err != nil {
+		return err
+	}
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case c.WriteChan <- rpc:
 		return nil
+	case err := <-c.ErrorChan:
+		return err
 	}
+}
+
+func (c *TestConn) CurrentReaders() int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.readers
+}
+
+func (c *TestConn) CurrentWriters() int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.writers
+}
+
+func (c *TestConn) InjectError(err error) {
+	c.lock.Lock()
+	c.error = err
+	c.lock.Unlock()
+
+	c.ErrorChan <- err
+	c.ErrorChan <- err
 }

--- a/server.go
+++ b/server.go
@@ -198,18 +198,15 @@ func (h *handler) serve(clientCtx context.Context) error {
 		}
 	}()
 
-	writeCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	go func() {
 		for {
 			select {
 			case rpc := <-h.writeChan:
-				err := h.rw.Write(writeCtx, rpc)
+				err := h.rw.Write(h.ctx, rpc)
 				if err != nil {
 					h.cancel(fmt.Errorf("write error: %v", err))
 				}
-			case <-writeCtx.Done():
+			case <-h.ctx.Done():
 				return
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -588,7 +588,6 @@ func (h *handler) resetStream(rpc *goatorepo.Rpc) error {
 		reset.Header.ProxyNext = rpc.Header.ProxyRecord[0 : len(rpc.Header.ProxyRecord)-1]
 	}
 
-	// XXX: error handling?
 	return h.rw.Write(h.ctx, reset)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -552,10 +552,6 @@ func TestServerStream(t *testing.T) {
 	})
 }
 
-// Streams:
-//  - replies are sent by stream.go; SendMsg(). This handles websocket errors just fine.
-//  - resetStream() also writes to the websocket and doesn't check error
-
 func expectStatsHandleConn[StatsType stats.ConnStats](m *grpcStatsMocks.MockHandler) *grpcStatsMocks.MockHandler_HandleConn_Call {
 	return m.EXPECT().HandleConn(mock.Anything, mock.MatchedBy(func(in stats.ConnStats) bool {
 		_, ok := in.(StatsType)

--- a/server_test.go
+++ b/server_test.go
@@ -473,6 +473,80 @@ func TestServerStream(t *testing.T) {
 		}
 		<-serverDone
 	})
+
+	t.Run("Handle HOL blocking and cleanup on write error", func(t *testing.T) {
+		is := require.New(t)
+
+		srv := NewServer("s0")
+		defer srv.Stop()
+
+		id := uint64(99)
+		method := testproto.TestService_ServiceDesc.ServiceName + "/ServerStream"
+		sent := testproto.Msg{Value: 10}
+
+		repliesSentChan := make(chan int, 10)
+		rpcDone := make(chan struct{}, 1)
+		serverDone := make(chan struct{}, 1)
+
+		service := mocks.NewMockTestServiceServer(t)
+		service.EXPECT().ServerStream(mock.Anything, mock.Anything).
+			Run(
+				func(m *testproto.Msg, stream testproto.TestService_ServerStreamServer) {
+					fmt.Println("Stream handler", sent.Value)
+					defer func() { fmt.Println("Stream handler completed"); rpcDone <- struct{}{} }()
+
+					for i := 0; i < int(sent.Value); i++ {
+						err := stream.Send(&testproto.Msg{Value: int32(i)})
+						if err != nil {
+							return
+						}
+						repliesSentChan <- i
+					}
+				},
+			).
+			Return(nil)
+
+		testproto.RegisterTestServiceServer(srv, service)
+
+		conn := testutil.NewTestConn()
+
+		go func() {
+			srv.Serve(context.Background(), conn)
+			serverDone <- struct{}{}
+		}()
+
+		// Open stream
+		conn.ReadChan <- testutil.ReadReturn{
+			Rpc: &goatorepo.Rpc{
+				Id: id,
+				Header: &goatorepo.RequestHeader{
+					Method:      method,
+					Source:      "c0",
+					Destination: "s0",
+				},
+			},
+			Err: nil,
+		}
+
+		// SendMsg
+		conn.ReadChan <- testutil.ReadReturn{Rpc: wrapRpc(id, method, &sent, "c0", "s0"), Err: nil}
+
+		// The server stream handler will now end up blocking on writing to the "conn". Let's just
+		// poll until we're definitely in this state
+		// First, check a single reply has definitely been sent, filling the reply channel
+		is.Equal(0, <-repliesSentChan)
+		// Then, check that the server is stuck waiting on a write
+		for conn.CurrentWriters() != 1 {
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		// Now inject an error
+		conn.InjectError(fmt.Errorf("broken pipe or something"))
+
+		// Now everything should return and clean up
+		<-rpcDone
+		<-serverDone
+	})
 }
 
 func expectStatsHandleConn[StatsType stats.ConnStats](m *grpcStatsMocks.MockHandler) *grpcStatsMocks.MockHandler_HandleConn_Call {

--- a/server_test.go
+++ b/server_test.go
@@ -553,7 +553,10 @@ func TestServerStream(t *testing.T) {
 
 		// Now everything should return and clean up
 		<-rpcDone
-		is.EqualError(<-serverDone, "read error: broken pipe or something")
+
+		// The actual error info (write error) is lost because the error is flowed through with
+		// context cancellation
+		is.EqualError(<-serverDone, "context canceled")
 	})
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -492,8 +492,7 @@ func TestServerStream(t *testing.T) {
 		service.EXPECT().ServerStream(mock.Anything, mock.Anything).
 			Run(
 				func(m *testproto.Msg, stream testproto.TestService_ServerStreamServer) {
-					fmt.Println("Stream handler", sent.Value)
-					defer func() { fmt.Println("Stream handler completed"); rpcDone <- struct{}{} }()
+					defer func() { rpcDone <- struct{}{} }()
 
 					for i := 0; i < int(sent.Value); i++ {
 						err := stream.Send(&testproto.Msg{Value: int32(i)})


### PR DESCRIPTION
The unit test should cover the case being fixed quite well. I verified that before the fix, the unit test would just hang then timeout, as expected.

The problem being fixed here is that we could end up deadlocked if there was an error on the underlying connection (e.g. websocket) because we didn't check for errors from `.Write()` and flow those through, instead relying on `.Read()` errors... Which was fine, until we found a codepath that resulted in the goroutine not waiting in read, but being blocked effectively by the write.